### PR TITLE
uncomment COMMIT_INFO_MESSAGE

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -37,4 +37,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # - if the event is push, the title will be undefined and Cypress will get the commit message from Git information
           # - if the event is pull_request, then we set the commit message to the pull request title
-          # COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Testing to see if adding `COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}` prevents any combo of Cypress bot or status checks from appearing.