### PR TITLE
commenting out COMMIT_INFO_MESSAGE

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -37,4 +37,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # - if the event is push, the title will be undefined and Cypress will get the commit message from Git information
           # - if the event is pull_request, then we set the commit message to the pull request title
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+          # COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Checking to see if, prior to merging `github.event.pull_request.title`, if the behavior will return